### PR TITLE
Fix axe-cli for release

### DIFF
--- a/lib/axe-test-urls.js
+++ b/lib/axe-test-urls.js
@@ -28,20 +28,19 @@ function testPages(urls, config, events) {
 		if (events.onTestStart) {
 			events.onTestStart(currentUrl);
 		}
-
 		driver.get(currentUrl)
 		.then(function () {
-	  	// Wait for the page to be loaded
-	  	return driver.executeAsyncScript(function(callback) {
-          var script = document.createElement('script');
-          script.innerHTML = 'document.documentElement.classList.add("deque-axe-is-ready");';
-          document.documentElement.appendChild(script);
-          callback();
-        });
-      })
-      .then(function () {
-        return driver.wait(WebDriver.until.elementsLocated(WebDriver.By.css('.deque-axe-is-ready')));
-      })
+		  	// Wait for the page to be loaded
+		  	return driver.executeAsyncScript(function(callback) {
+	          var script = document.createElement('script');
+	          script.innerHTML = 'document.documentElement.classList.add("deque-axe-is-ready");';
+	          document.documentElement.appendChild(script);
+	          callback();
+	        });
+	    })
+	    .then(function () {
+	        return driver.wait(WebDriver.until.elementsLocated(WebDriver.By.css('.deque-axe-is-ready')));
+	    })
 		.then(() => {
 			// Set everything up
 			const axe = AxeBuilder(driver, config.axeSource)
@@ -72,7 +71,7 @@ function testPages(urls, config, events) {
 				.then(out => {
 					resolve([results].concat(out))
 				});
-	    });
+		    });
 		}).catch((e) => {
 			driver.quit();
 			reject(e)

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -24,7 +24,7 @@ function startDriver(config) {
 			config.phantom = phantom;
 
 			// And connect selenium to our phantom server
-			config.driver = builder.usingServer('http://localhost:4444').build();
+			config.driver = builder.usingServer('http://localhost:4444/wd/hub').build();
 			config.driver.manage().timeouts().setScriptTimeout(90*1000)
 
 			return Promise.resolve(config);

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -34,7 +34,6 @@ function startDriver(config) {
 }
 
 function stopDriver(config) {
-	config.driver.quit();
 	if (config.phantom) {
 		config.phantom.kill();
 	}

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/dequelabs/axe-cli#readme",
   "dependencies": {
-    "axe-core": "^2.0.7",
-    "axe-webdriverjs": "^1.1.0",
+    "axe-core": "^2.1.7",
+    "axe-webdriverjs": "^0.5.0",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "phantomjs-prebuilt": "^2.1.13",


### PR DESCRIPTION
I couldn't run axe-cli at all without these changes–I kept running into Issue #3 and the only way to fix it was to remove the call to `config.driver.quit()` in [lib/webdriver.js](https://github.com/dequelabs/axe-cli/blob/master/lib/webdriver.js#L37). I couldn't find a way to check for a driver session id before making that call, so the solution was to remove it since it threw an error in `.catch(e)` in [axe-test-urls.js:77](https://github.com/dequelabs/axe-cli/blob/master/lib/axe-test-urls.js#L77), even after results had successfully completed:
```
Error: ECONNREFUSED connect ECONNREFUSED 127.0.0.1:4444
    at ClientRequest.<anonymous> (/Users/marcysutton/Sites/Deque/axe-cli/node_modules/selenium-webdriver/http/index.js:238:15)
    at emitOne (events.js:96:13)
    at ClientRequest.emit (events.js:188:7)
    at Socket.socketErrorListener (_http_client.js:310:9)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at emitErrorNT (net.js:1276:8)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
From: Task: WebDriver.quit()
    at WebDriver.schedule (/Users/marcysutton/Sites/Deque/axe-cli/node_modules/selenium-webdriver/lib/webdriver.js:816:17)
    at WebDriver.quit (/Users/marcysutton/Sites/Deque/axe-cli/node_modules/selenium-webdriver/lib/webdriver.js:849:23)
    at stopDriver (/Users/marcysutton/Sites/Deque/axe-cli/lib/webdriver.js:39:17)
    at testPages (/Users/marcysutton/Sites/Deque/axe-cli/lib/axe-test-urls.js:26:3)
    at /Users/marcysutton/Sites/Deque/axe-cli/lib/axe-test-urls.js:80:5
    at ManagedPromise.invokeCallback_ (/Users/marcysutton/Sites/Deque/axe-cli/node_modules/selenium-webdriver/lib/promise.js:1366:14)
    at TaskQueue.execute_ (/Users/marcysutton/Sites/Deque/axe-cli/node_modules/selenium-webdriver/lib/promise.js:2970:14)
    at TaskQueue.executeNext_ (/Users/marcysutton/Sites/Deque/axe-cli/node_modules/selenium-webdriver/lib/promise.js:2953:27)
    at asyncRun (/Users/marcysutton/Sites/Deque/axe-cli/node_modules/selenium-webdriver/lib/promise.js:2813:27)
    at /Users/marcysutton/Sites/Deque/axe-cli/node_modules/selenium-webdriver/lib/promise.js:676:7
```
Removing that call didn't seem to affect the functionality: I could run axe-cli on multiple URLs and it returned results successfully, multiple times in a row. I think when you kill off Phantomjs it takes down the driver anyway, so there is nothing left running on port 4444.

I also added a fix for the Selenium URL since it would return an HTML error page on the Selenium website otherwise. 

Closes #3.