### PR TITLE
fix: add node version restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "A CLI for accessibility testing using axe-core",
   "main": "index.js",
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {},
   "repository": {
     "type": "git",


### PR DESCRIPTION
When running `axe-cli` in in node version smaller than 6 (this is a least what I tested) it throws the following error:

```
> axe https://www.stefanjudis.de
/Users/stefanjudis/.nvm/versions/node/v5.12.0/lib/node_modules/axe-cli/node_modules/selenium-webdriver/index.js:115
  static createSession(...args) {}
                       ^^^

SyntaxError: Unexpected token ...
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:387:25)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/stefanjudis/.nvm/versions/node/v5.12.0/lib/node_modules/axe-cli/lib/axe-test-urls.js:3:19)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
```

To help future users it might make sense to define a proper version, so that npm could potentially warn the user.