### PR TITLE
Upgrade axe-core and fix webdriver issue

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -34,6 +34,9 @@ function startDriver(config) {
 }
 
 function stopDriver(config) {
+	if (config.browser !== 'phantomjs') {
+		config.driver.quit();
+	}
 	if (config.phantom) {
 		config.phantom.kill();
 	}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/dequelabs/axe-cli#readme",
   "dependencies": {
-    "axe-core": "^2.1.7",
+    "axe-core": "^2.2.0",
     "axe-webdriverjs": "^0.5.0",
     "colors": "^1.1.2",
     "commander": "^2.9.0",


### PR DESCRIPTION
The initial fix I shipped for https://github.com/dequelabs/axe-cli/issues/3 caused a second problem–by not closing the browser to avoid the error, Webdriver runs leave a browser instance open. I was able to fix that by adding the call back in but wrapping it in a Phantomjs config check. I also updated to axe-core 2.2.0