### PR TITLE
Improve Exit Codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ program.version(version)
 .option('-s, --save [filename]', 'Save the output as a JSON file. Filename is optional')
 .option('-d, --dir <path>', 'Output directory')
 .option('-a, --axe-source', 'Path to axe.js file')
+.option('-q, --exit', 'Exit with `1` failure code if any a11y tests fail')
 // .option('-c, --config <file>', 'Path to custom axe configuration')
 .parse(process.argv);
 
@@ -39,6 +40,7 @@ if (urls.length === 0) {
 	console.log(error(
 		'No url was specified. Check `axe -h` for help\n'
 	))
+	process.exitCode = 1;
 	return;
 }
 
@@ -81,6 +83,10 @@ axeTestUrls(urls, program, {
 		}, 0);
 
 		console.log(error('\n%d Accessibility issues detected.'), issueCount)
+
+		if (program.exit) {
+			process.exitCode = 1;
+		}
 	}
 }).then(function (outcome) {
 	// All results are in, quit the browser, and give a final report
@@ -97,6 +103,7 @@ axeTestUrls(urls, program, {
 			console.log('\nSaved file at', fileName)
 		}).catch(err => {
 			console.log(error('\nUnable to save file!\n') + err);
+			process.exitCode = 1;
 			return Promise.resolve();
 		})
 	} else {
@@ -113,6 +120,8 @@ axeTestUrls(urls, program, {
 		'https://dequeuniversity.com/curriculum/courses/testing'
 	));
 }).catch((e) => {
+	process.exitCode = 1;
+
 	// On error, report it and quit the browser
 	console.log(
 		colors.red('Error: %j \n $s'),

--- a/readme.MD
+++ b/readme.MD
@@ -70,3 +70,12 @@ To run axe-cli using another browser, pass it in as the `--browser` option:
 Or for short:
 
 	axe www.deque.com -b c
+
+### CI integration
+
+Axe-cli can be ran within the CI tooling for your project. Many tools are automatically configured to halt/fail builds when a process exits with a code of `1`.  
+
+Use the `--exit` flag, `-q` for short, to have the axe-cli process exit with a failure code `1` when any rule fails to pass.
+
+	axe www.deque.com --exit
+


### PR DESCRIPTION
- add `--exit`, `-q` flag
- a11y test `1` exit code behind the flag
- better exit codes for other failures/errors
- readme documentation

closes #20