### PR TITLE
Automate release prep with standard-version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+
+## Contributor License Agreement
+
+In order to contribute, you must accept the [contributor license agreement](https://cla-assistant.io/dequelabs/axe-core) (CLA). Acceptance of this agreement will be checked automatically and pull requests without a CLA cannot be merged.
+
+## Contribution Guidelines
+
+Submitting code to the project? Please review and follow the axe-core
+[Git commit and pull request guidelines](https://github.com/dequelabs/axe-core/blob/develop/doc/code-submission-guidelines.md).
+
+### Code Quality
+
+Although we do not have official code style guidelines, we can and will request you to make changes
+if we think that your code is sloppy. You can take clues from the existing code base to see what we
+consider to be reasonable code quality. Please be prepared to make changes that we ask of you even
+if you might not agree with the request(s).
+
+Pull requests that change the tabs of a file (spacing or changes from spaces to tabs and vice versa)
+will not be accepted. Please respect the coding style of the files you are changing and adhere to that.
+
+That having been said, we prefer:
+
+1. Tabs over spaces
+2. Single quotes for string literals
+3. Function definitions like `function functionName(arguments) {`
+4. Variable function definitions like `Class.prototype.functionName = function (arguments) {`
+5. Use of 'use strict'
+6. Variables declared at the top of functions
+
+### Testing
+
+We expect all code to be covered by tests. We don't have or want code coverage metrics but we will review tests and suggest changes when we think the test(s) do(es) not adequately exercise the code/code changes.
+
+### Documentation and Comments
+
+Functions should contain a preceding comment block with [jsdoc](http://usejsdoc.org/) style documentation of the function. For example:
+
+```
+/**
+ * Runs the Audit; which in turn should call `run` on each rule.
+ * @async
+ * @param  {Context}   context The scope definition/context for analysis (include/exclude)
+ * @param  {Object}    options Options object to pass into rules and/or disable rules or checks
+ * @param  {Function} fn       Callback function to fire when audit is complete
+ */
+```
+
+## Setting up your environment
+
+In order to get going, fork and clone the repository. Then, if you do not have [Node.js](https://nodejs.org/download/) installed, install it!
+
+Once the basic infrastructure is installed, from the repository root, do the following:
+
+```
+npm install
+```
+
+To run axe-cli from your development environment, run:
+
+```
+node index.js www.deque.com
+```
+


### PR DESCRIPTION
Manually updating the version is super error-prone, and it already bit me once with axe-cli (I meant to release 1.1.0, yet somehow it got updated to 1.1.1). 

We should use the same process as axe-core for this instead of doing it by hand. Since I'm the one typically releasing our open source modules, I'd really prefer a single process. The only difference with axe-cli is it doesn't use sri-history. I know we're moving to attest-master for Bitbucket repos, but this will give us a workable solution for Github now.

I guess to go along with this change: we should stop incrementing the version by hand until we're ready to release. It's confusing to go hunt it down every time when I'm releasing code.