### PR TITLE
docs(contributing): fix CLA link for this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Contributor License Agreement
 
-In order to contribute, you must accept the [contributor license agreement](https://cla-assistant.io/dequelabs/axe-core) (CLA). Acceptance of this agreement will be checked automatically and pull requests without a CLA cannot be merged.
+In order to contribute, you must accept the [contributor license agreement](https://cla-assistant.io/dequelabs/axe-cli) (CLA). Acceptance of this agreement will be checked automatically and pull requests without a CLA cannot be merged.
 
 ## Contribution Guidelines
 


### PR DESCRIPTION
Fix CLA link so it goes to CLA for the `axe-cli` repo instead of the one for the `axe-core` repo.