### PR TITLE
test: make "ready class" test more forgiving

### DIFF
--- a/test/axe-test-urls.js
+++ b/test/axe-test-urls.js
@@ -56,10 +56,10 @@ describe('testPages', function () {
 
 		await testPages(['http://foo'], config, {})
 
-		assert.include(
-			asyncScripts[0].toString(),
-			'.innerHTML = \'document.documentElement.classList.add("deque-axe-is-ready");\''
-		)
+		assert.equal(asyncScripts.length, 2)
+		const [script]=asyncScripts
+		assert.match(script, /script\.innerHTML\s*=[\s\S]*['"]document\.documentElement\.classList\.add\(['"]deque-axe-is-ready/)
+
 		assert.equal(waitCalls, 1)
 	})
 


### PR DESCRIPTION
This patch updates one of our test cases, making it much less brittle. Rather than using whitespace-sensitive string comparison, we're now using a regular expression.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Jey
