### PR TITLE
feat: add `--chrome-options` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Or for short:
 axe www.deque.com -b c
 ```
 
+## Custom Chrome Flags
+
+When using the Headless Chrome browser, you may provide any number of [flags to configure how the browser functions](https://peter.sh/experiments/chromium-command-line-switches/).
+
+Options are passed by name, without their leading `--` prefix. For example, to provide the `--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage` flags to the Chrome binary, you'd do:
+
+```
+axe --chrome-options="no-sandbox,disable-setuid-sandbox,disable-dev-shm-usage" www.deque.com
+```
+
 ## CI integration
 
 Axe-cli can be ran within the CI tooling for your project. Many tools are automatically configured to halt/fail builds when a process exits with a code of `1`.

--- a/index.js
+++ b/index.js
@@ -64,6 +64,11 @@ program
 	// TODO: Replace this with a reporter option, this required adding
 	// a reporter option to axe-webdriverjs
 	.option('--no-reporter', 'Turn the CLI reporter off')
+	.option(
+		'--chrome-options [options]',
+		'Options to provide to headless Chrome',
+		utils.splitList
+	)
 
 	// .option('-c, --config <file>', 'Path to custom axe configuration')
 	.parse(process.argv);
@@ -74,6 +79,17 @@ program.axeSource = utils.getAxeSource(program.axeSource);
 if (!program.axeSource) {
 	console.log(error('Unable to find the axe-core source file.'));
 	return;
+}
+
+if (program.chromeOptions) {
+	if (program.browser !== 'chrome-headless') {
+		console.error(
+			error('You may only provide --chrome-options when using headless chrome')
+		);
+		process.exit(2);
+	}
+
+	program.chromeOptions = program.chromeOptions.map(option => `--${option}`);
 }
 
 let cliReporter;

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -16,10 +16,13 @@ function startDriver(config) {
 		const service = new chrome.ServiceBuilder(chromedriver.path).build();
 		chrome.setDefaultService(service);
 
+		const args = ['--headless'];
+		if (config.chromeOptions) {
+			args.push(config.chromeOptions);
+		}
+
 		const chromeCapabilities = Capabilities.chrome();
-		chromeCapabilities.set('chromeOptions', {
-			args: ['--headless'].concat(config.chromeOptions)
-		});
+		chromeCapabilities.set('chromeOptions', { args });
 
 		builder = new Builder()
 			.forBrowser('chrome')

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -18,7 +18,7 @@ function startDriver(config) {
 
 		const chromeCapabilities = Capabilities.chrome();
 		chromeCapabilities.set('chromeOptions', {
-			args: ['--headless']
+			args: ['--headless'].concat(config.chromeOptions)
 		});
 
 		builder = new Builder()


### PR DESCRIPTION
This patch adds a `--chrome-options="no-sandbox,disable-setuid-sandbox,..."` flag to the CLI. This flag can be used to provide any custom configuration flag to the Chrome binary.

Closes #65



## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu 
