### PR TITLE
chore: update `axe-core` and `axe-webdriverjs` deps

### DIFF
--- a/lib/axe-test-urls.js
+++ b/lib/axe-test-urls.js
@@ -91,10 +91,15 @@ function testPages(urls, config, events) {
 				}
 
 				// Run axe
-				axe.analyze(function(results) {
+				axe.analyze(function(err, results) {
 					if (config.timer) {
 						console.timeEnd('axe-core execution time');
 					}
+
+					if (err) {
+						return reject(err);
+					}
+
 					// Notify about the update
 					if (events.onTestComplete) {
 						events.onTestComplete(results);

--- a/package-lock.json
+++ b/package-lock.json
@@ -230,17 +230,41 @@
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
 		"axe-core": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.0.0.tgz",
-			"integrity": "sha512-wiN3mLDxkdjfHaSstkxEHzx+WFN9X520FBOA1z5T1jKbUcLqM+0wmhrhmesoaQknvjjaPq5uf0key7EXacmr0A=="
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.1.2.tgz",
+			"integrity": "sha512-e1WVs0SQu3tM29J9a/mISGvlo2kdCStE+yffIAJF6eb42FS+eUFEVz9j4rgDeV2TAfPJmuOZdRetWYycIbK7Vg=="
 		},
 		"axe-webdriverjs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-2.0.0.tgz",
-			"integrity": "sha512-2aWgu6DxJBz86Q2ioCYud3lzScmec4tNlk5haK+RHdhwPI+j52tTxuUwHAjriEFVXGoQkBc4NzKjdCY+bdiznw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-2.1.0.tgz",
+			"integrity": "sha512-0gX7SvxSqnT2OTDTiAYJPlqw08Lt+dGW24jQhQHgYZCp1kSuP17koKUbNxJNhU1bHITYSz9pK64me7om2Wn6gA==",
 			"requires": {
 				"axe-core": "^3.0.0",
-				"selenium-webdriver": ">= 2.53.1"
+				"babel-runtime": "^6.26.0",
+				"depd": "^2.0.0"
+			},
+			"dependencies": {
+				"depd": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+					"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+				}
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
+					"integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ=="
+				}
 			}
 		},
 		"balanced-match": {
@@ -3612,6 +3636,11 @@
 			"requires": {
 				"minimatch": "3.0.4"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regex-not": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
 	},
 	"homepage": "https://github.com/dequelabs/axe-cli#readme",
 	"dependencies": {
-		"axe-core": "^3.0.0",
-		"axe-webdriverjs": "^2.0.0",
+		"axe-core": "^3.1.2",
+		"axe-webdriverjs": "^2.1.0",
 		"chromedriver": "^2.36.0",
 		"colors": "^1.1.2",
 		"commander": "^2.9.0",


### PR DESCRIPTION
Additionally fix a deprecation warning from `axe-webdriverjs` v2.1.0.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu 
