### PR TITLE
chore: fix ESLint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"test": "mocha test/*.js",
-		"lint": "eslint .",
+		"lint": "eslint *.js lib/*.js test/*.js",
 		"fmt": "prettier --write *.{js,json,md} lib/*.js test/*.js"
 	},
 	"repository": {

--- a/test/axe-test-urls.js
+++ b/test/axe-test-urls.js
@@ -1,4 +1,3 @@
-/* global mocha */
 'use strict';
 
 const assert = require('chai').assert;

--- a/test/integrations.js
+++ b/test/integrations.js
@@ -1,4 +1,3 @@
-/* global mocha */
 'use strict';
 
 var assert = require('chai').assert;

--- a/test/webdriver.js
+++ b/test/webdriver.js
@@ -1,4 +1,3 @@
-/* global mocha */
 'use strict';
 
 const assert = require('chai').assert;


### PR DESCRIPTION
This patch removes an ESLint directive which declared `mocha` as a global variable. Since we never referenced the global, ESLint was erroring with:

```
/home/circleci/axe-cli/test/axe-test-urls.js
  1:11  error  'mocha' is defined but never used  no-unused-vars

/home/circleci/axe-cli/test/integrations.js
  1:11  error  'mocha' is defined but never used  no-unused-vars

/home/circleci/axe-cli/test/webdriver.js
  1:11  error  'mocha' is defined but never used  no-unused-vars

✖ 3 problems (3 errors, 0 warnings)
```

Additionally, the `lint` script now explicitly lists which files it "lints", rather than assuming ESLint is going to do what we want it to.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @WilcoFiers 
