### PR TITLE
chore: always use latest chromedriver

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	"dependencies": {
 		"axe-core": "^3.2.2",
 		"axe-webdriverjs": "^2.2.0",
-		"chromedriver": "*",
+		"chromedriver": "latest",
 		"colors": "^1.3.3",
 		"commander": "^2.19.0",
 		"selenium-webdriver": "^3.6.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	"dependencies": {
 		"axe-core": "^3.2.2",
 		"axe-webdriverjs": "^2.2.0",
-		"chromedriver": "^76.0.0",
+		"chromedriver": "*",
 		"colors": "^1.3.3",
 		"commander": "^2.19.0",
 		"selenium-webdriver": "^3.6.0"


### PR DESCRIPTION
We couldn't think of any reason to pin to specific versions of chormedriver, so will now always take the latest version and that should help prevent out of sync issues with chrome. 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
