### PR TITLE
ci: use `npm ci` to not override package-lock.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - checkout
       - restore_cache:
           key: v1-npm-cache-{{ checksum "package-lock.json" }}
-      - run: npm install
+      - run: npm ci
       - save_cache:
           key: v1-npm-cache-{{ checksum "package-lock.json" }}
           paths:


### PR DESCRIPTION
## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code reviewed for security
