### PR TITLE
feat: add option `chromedriver-path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,11 @@ To see additional information like test tool name, version and environment detai
 ```
 axe www.deque.com --verbose
 ```
+
+## ChromeDriver Path
+
+If you need to test your page using an older version of Chrome, you can use `--chromedriver-path` followed by the absolute path to the desired version of the ChromeDriver executable.
+
+```
+axe www.deque.com --chromedriver-path="absolute/path/to/chromedriver"
+```

--- a/index.js
+++ b/index.js
@@ -76,6 +76,10 @@ program
 		'-v, --verbose',
 		'Output metadata like test tool name, version and environment'
 	)
+	.option(
+		'--chromedriver-path',
+		'Absolute path to the desired chromedriver executable'
+	)
 	// .option('-c, --config <file>', 'Path to custom axe configuration')
 	.parse(process.argv);
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ program
 		'Output metadata like test tool name, version and environment'
 	)
 	.option(
-		'--chromedriver-path',
+		'--chromedriver-path <path>',
 		'Absolute path to the desired chromedriver executable'
 	)
 	// .option('-c, --config <file>', 'Path to custom axe configuration')

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -13,7 +13,9 @@ function startDriver(config) {
 
 	if (config.browser === 'chrome-headless') {
 		// Tell selenium use the driver in node_modules
-		const service = new chrome.ServiceBuilder(chromedriver.path).build();
+		const service = new chrome.ServiceBuilder(
+			config.chromedriverPath || chromedriver.path
+		).build();
 		chrome.setDefaultService(service);
 
 		const args = ['--headless'];

--- a/test/webdriver.js
+++ b/test/webdriver.js
@@ -4,6 +4,7 @@ const assert = require('chai').assert;
 const { startDriver, stopDriver } = require('../lib/webdriver');
 const chromedriver = require('chromedriver');
 const chrome = require('selenium-webdriver/chrome');
+const path = require('path');
 
 describe('startDriver', () => {
 	let config, browser;
@@ -61,6 +62,16 @@ describe('startDriver', () => {
 		const service = chrome.getDefaultService();
 
 		assert.equal(service.executable_, chromedriver.path);
+	});
+
+	it('uses the passed in chromedriver path with chrome-headless', async () => {
+		browser = 'chrome-headless';
+		config.chromedriverPath = path.relative(process.cwd(), chromedriver.path);
+		await startDriver(config);
+		const service = chrome.getDefaultService();
+
+		assert.notEqual(config.chromedriverPath, chromedriver.path);
+		assert.equal(service.executable_, config.chromedriverPath);
 	});
 
 	it('sets the --headless flag with chrome-headless', async () => {


### PR DESCRIPTION
Add option to CLI to specify the path to the desired ChromeDriver. Allows users to use the specific version of the ChromeDriver that is compatible with their version of Chrome.

```bash
axe dequeuniversity --chromedriver-path "path/to/driver"
```

Closes issue: #103 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
