### PR TITLE
chore: update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - restore_cache:
           key: v1-npm-cache-{{ checksum "package-lock.json" }}
       - run: npm ci
+      - run: npm install chromedriver@latest
       - save_cache:
           key: v1-npm-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/package-lock.json
+++ b/package-lock.json
@@ -611,9 +611,9 @@
 			"dev": true
 		},
 		"chromedriver": {
-			"version": "76.0.0",
-			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-76.0.0.tgz",
-			"integrity": "sha512-jGyqs0N+lMo9iaNQxGKNPiLJWb2L9s2rwbRr1jJeQ37n6JQ1+5YMGviv/Fx5Z08vBWYbAvrKEzFsuYf8ppl+lw==",
+			"version": "78.0.1",
+			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-78.0.1.tgz",
+			"integrity": "sha512-eOsyFk4xb9EECs1VMrDbxO713qN+Bu1XUE8K9AuePc3839TPdAegg72kpXSzkeNqRNZiHbnJUItIVCLFkDqceA==",
 			"requires": {
 				"del": "^4.1.1",
 				"extract-zip": "^1.6.7",
@@ -2554,9 +2554,9 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.1.2",
-			"resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/handlebars/-/handlebars-4.1.2.tgz",
-			"integrity": "sha1-trN8HO0DBrIh4JT8eso+wjsTG2c=",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+			"integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -2567,8 +2567,8 @@
 			"dependencies": {
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
 			}
@@ -2706,15 +2706,24 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^4.1.0",
+				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
 			},
 			"dependencies": {
+				"agent-base": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+					"dev": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				},
 				"debug": {
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -2725,9 +2734,9 @@
 					}
 				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
@@ -3809,16 +3818,16 @@
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+			"integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
 		},
 		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"version": "2.1.25",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+			"integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
 			"requires": {
-				"mime-db": "1.40.0"
+				"mime-db": "1.42.0"
 			}
 		},
 		"mimic-fn": {
@@ -4023,8 +4032,8 @@
 		},
 		"neo-async": {
 			"version": "2.6.1",
-			"resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
 			"dev": true
 		},
 		"netmask": {
@@ -4576,9 +4585,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
-			"integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
 		},
 		"pump": {
 			"version": "3.0.0",
@@ -6451,20 +6460,27 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"uglify-js": {
-			"version": "3.6.0",
-			"resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/uglify-js/-/uglify-js-3.6.0.tgz",
-			"integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
+			"version": "3.6.9",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+			"integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"commander": "~2.20.0",
+				"commander": "~2.20.3",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true,
+					"optional": true
+				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true,
 					"optional": true
 				}


### PR DESCRIPTION
Our CircleCI npm cache is based on the hash of the package-lock file. However, we run `npm ci` in circle so the package-lock file isn't updated for new installs. This means that using `chromedriver: latest` will never trigger a new install of Chromedriver until we update the package-lock file ourselves and make a push... https://circleci.com/gh/dequelabs/axe-cli/374?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

So I made chromedriver install the latest always for CircleCI.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
