### PR TITLE
fix: Enable using of --chrome-options argument

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -20,7 +20,7 @@ function startDriver(config) {
 
 		const args = ['--headless'];
 		if (config.chromeOptions) {
-			args.push(config.chromeOptions);
+			args.push(...config.chromeOptions);
 		}
 
 		const chromeCapabilities = Capabilities.chrome();

--- a/test/webdriver.js
+++ b/test/webdriver.js
@@ -83,6 +83,17 @@ describe('startDriver', () => {
 		assert.isObject(chromeOptions);
 		assert.deepEqual(chromeOptions.args, ['--headless']);
 	});
+
+	it('sets the --chrome-options flag with no-sandbox', async () => {
+		browser = 'chrome-headless';
+		config.chromeOptions = ['--no-sandbox'];
+		const { builder } = await startDriver(config);
+		const capabilities = await builder.getCapabilities();
+		const chromeOptions = capabilities.get('chromeOptions');
+
+		assert.isArray(chromeOptions.args);
+		assert.deepEqual(chromeOptions.args, ['--headless', '--no-sandbox']);
+	});
 });
 
 describe('stopDriver', () => {


### PR DESCRIPTION
Spread the array that was being merged so there are no issues when using the `--chrome-options` flag. This should allow users to pass in `no-sandbox` to work with Linux users. 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
