### PR TITLE
docs: fix '--verbose' option typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ axe www.deque.com --load-delay=2000
 
 ## Verbose output
 
-To see additional information like test tool name, version and environment details, use the `--version` flag, `-v` for short.
+To see additional information like test tool name, version and environment details, use the `--verbose` flag, `-v` for short.
 
 ```
 axe www.deque.com --verbose


### PR DESCRIPTION
I fixed the wrong option for verbose output

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
