### PR TITLE
fix: run Chrome on Linux

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -18,7 +18,7 @@ function startDriver(config) {
 		).build();
 		chrome.setDefaultService(service);
 
-		const args = ['--headless'];
+		const args = ['--headless', '--no-sandbox'];
 		if (config.chromeOptions) {
 			args.push(...config.chromeOptions);
 		}

--- a/test/webdriver.js
+++ b/test/webdriver.js
@@ -81,18 +81,32 @@ describe('startDriver', () => {
 		const chromeOptions = capabilities.get('chromeOptions');
 
 		assert.isObject(chromeOptions);
-		assert.deepEqual(chromeOptions.args, ['--headless']);
+		assert.isTrue(chromeOptions.args.includes('--headless'));
 	});
 
-	it('sets the --chrome-options flag with no-sandbox', async () => {
+	it('sets the --no-sandbox flag with chrome-headless', async () => {
 		browser = 'chrome-headless';
-		config.chromeOptions = ['--no-sandbox'];
+		const { builder } = await startDriver(config);
+		const capabilities = await builder.getCapabilities();
+		const chromeOptions = capabilities.get('chromeOptions');
+
+		assert.isObject(chromeOptions);
+		assert.isTrue(chromeOptions.args.includes('--no-sandbox'));
+	});
+
+	it('sets the --chrome-options flag with custom args', async () => {
+		browser = 'chrome-headless';
+		config.chromeOptions = ['window-size=1024,768'];
 		const { builder } = await startDriver(config);
 		const capabilities = await builder.getCapabilities();
 		const chromeOptions = capabilities.get('chromeOptions');
 
 		assert.isArray(chromeOptions.args);
-		assert.deepEqual(chromeOptions.args, ['--headless', '--no-sandbox']);
+		assert.deepEqual(chromeOptions.args, [
+			'--headless',
+			'--no-sandbox',
+			'window-size=1024,768'
+		]);
 	});
 });
 


### PR DESCRIPTION
Add the `--no-sandbox` ChromeOption which should allow Chrome to start on Linux (see https://github.com/SeleniumHQ/selenium/issues/4961#issuecomment-350108756)

Closes issue: #84

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
