### PR TITLE
fix: drop node v6/7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "A CLI for accessibility testing using axe-core",
 	"main": "index.js",
 	"engines": {
-		"node": ">=6"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "mocha test/*.js",


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS 6 and NodeJS 7

Closes issue: #133 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
