### PR TITLE
chore: remove greenkeeper badge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,11 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-npm-cache-{{ checksum "package-lock.json" }}
+          key: v2-npm-cache-{{ checksum "package-lock.json" }}
       - run: npm ci
       - run: npm install chromedriver@latest
       - save_cache:
-          key: v1-npm-cache-{{ checksum "package-lock.json" }}
+          key: v2-npm-cache-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
   tests:
@@ -23,7 +23,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-npm-cache-{{ checksum "package-lock.json" }}
+          key: v2-npm-cache-{{ checksum "package-lock.json" }}
       - run: npm run lint
       - run: npm test
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # axe-cli
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/dequelabs/axe-cli.svg)](https://greenkeeper.io/)
-
 [![Join the chat at https://gitter.im/dequelabs/axe-core](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dequelabs/axe-core?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Version](https://img.shields.io/npm/v/axe-cli.svg)](https://www.npmjs.com/package/axe-cli)
 [![License](https://img.shields.io/npm/l/axe-cli.svg)](LICENSE)


### PR DESCRIPTION
Noticed we do not have `greenkeeper.json` in this repo, that in my understanding means greenkeeper is not wired up? Hence removing this badge.

Closes issue:
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
